### PR TITLE
Detect AWK filetype by shebang

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,7 +14,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <fileType name="AWK File" implementationClass="intellij_awk.AwkFileType"
-                  fieldName="INSTANCE" language="AWK" extensions="awk"/>
+                  fieldName="INSTANCE" language="AWK" extensions="awk" hashBangs="awk"/>
         <lang.parserDefinition language="AWK"
                                implementationClass="intellij_awk.AwkParserDefinition"/>
         <lang.syntaxHighlighterFactory language="AWK"


### PR DESCRIPTION
Simple fix using `fileType.hashBang` ([ref](https://plugins.jetbrains.com/docs/intellij/registering-file-type.html#registration))